### PR TITLE
Publish `send-email` events on `POST /mail`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 test
+.git
+node_modules/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,10 @@
 extends: airbnb-base
 env:
   mocha: true
-
 globals:
   expect: true
   sinon: true
+rules:
+  comma-dangle:
+    - error
+    - always-multiline

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 services:
   - docker
 
-script: ./auto/dev-environment npm test
+script: ./auto/dev-environment npm run ci
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then auto/docker-build-release; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,1 @@
-FROM node:7
-
-RUN mkdir -p /app
-WORKDIR /app
-COPY . /app
-
-ENV NODE_ENV production
-RUN npm install
-
-EXPOSE 3000
-CMD npm start
+FROM rabblerouser/node-base

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "eslint-config-airbnb-base": "^11.3.2",
     "eslint-plugin-import": "^2.7.0",
     "mocha": "^3.3.0",
-    "nodemon": "^1.11.0"
+    "nodemon": "^1.11.0",
+    "sinon": "^3.2.1",
+    "sinon-chai": "^2.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@rabblerouser/stream-client": "^0.8.8",
+    "aws-sdk": "^2.108.0",
     "body-parser": "^1.17.2",
     "express": "^4.15.2",
     "morgan": "^1.8.2",
     "redux": "^3.7.2",
+    "uuid": "^3.1.0",
     "winston": "^2.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "nodemon index.js",
     "start": "node index.js",
+    "ci": "npm run lint && npm test",
     "lint": "eslint src",
     "test": "NODE_ENV=test mocha -r src/__tests__/testGlobals --recursive src"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "@rabblerouser/stream-client": "^0.8.8",
     "body-parser": "^1.17.2",
     "express": "^4.15.2",
-    "redux": "^3.7.2"
+    "morgan": "^1.8.2",
+    "redux": "^3.7.2",
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "aws-sdk": "^2.108.0",
     "body-parser": "^1.17.2",
     "express": "^4.15.2",
+    "mailparser": "^2.0.5",
     "morgan": "^1.8.2",
     "redux": "^3.7.2",
     "uuid": "^3.1.0",

--- a/src/__tests__/sendGroupMailTest.js
+++ b/src/__tests__/sendGroupMailTest.js
@@ -48,7 +48,9 @@ describe('sendGroupMail', () => {
           from: 'admin@example.com',
           to: ['john@example.com', 'jane@example.com'],
           subject: 'Some Subject',
-          bodyLocation: 'email-object',
+          bodyLocation: {
+            bodyLocation: 'email-object',
+          },
         });
         expect(res.status).to.have.been.calledWith(202);
       });

--- a/src/__tests__/sendGroupMailTest.js
+++ b/src/__tests__/sendGroupMailTest.js
@@ -1,0 +1,24 @@
+const sendGroupMail = require('../sendGroupMail');
+
+describe('sendGroupMail', () => {
+  let sandbox;
+  let res;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    res = {
+      send: sandbox.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('gives a 202', () => {
+    sendGroupMail({}, res);
+
+    expect(res.send).to.have.been.calledWith(202);
+  });
+});

--- a/src/__tests__/sendGroupMailTest.js
+++ b/src/__tests__/sendGroupMailTest.js
@@ -30,10 +30,7 @@ describe('sendGroupMail', () => {
     sandbox.stub(mailParser, 'simpleParser').withArgs('Some email body').returns(emailData());
     sandbox.stub(streamClient, 'publish').resolves();
     sandbox.stub(uuid, 'v4').returns('some-uuid');
-    sandbox.stub(store, 'getMembers').returns([
-      { email: 'john@example.com' },
-      { email: 'jane@example.com' },
-    ]);
+    sandbox.stub(store, 'getMemberEmails').returns(['john@example.com', 'jane@example.com']);
   });
 
   afterEach(() => {

--- a/src/__tests__/testGlobals.js
+++ b/src/__tests__/testGlobals.js
@@ -1,5 +1,10 @@
 const chai = require('chai');
 
+chai.use(require('sinon-chai'));
+
 chai.should();
+
 global.expect = chai.expect;
+global.sinon = require('sinon');
+
 global.chai = chai;

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,10 @@ streamClient.on('member-registered', store.registerMember);
 streamClient.on('member-removed', store.removeMember);
 streamClient.on('member-edited', store.editMember);
 
+streamClient.on('admin-created', store.createAdmin);
+streamClient.on('admin-removed', store.removeAdmin);
+streamClient.on('admin-edited', store.editAdmin);
+
 app.post('/events', streamClient.listen());
 app.post('/mail', sendGroupMail);
 

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser');
 const morgan = require('morgan');
 const streamClient = require('./streamClient');
 const store = require('./store');
+const sendGroupMail = require('./sendGroupMail');
 
 const app = express();
 if (process.env.NODE_ENV !== 'test') {
@@ -15,11 +16,7 @@ streamClient.on('member-removed', store.deleteMember);
 streamClient.on('member-edited', store.updateMember);
 
 app.post('/events', streamClient.listen());
-
-app.post('/mail', (req, res) => {
-  console.log(req.body);
-  res.sendStatus(202);
-});
+app.post('/mail', sendGroupMail);
 
 app.get('/status', (req, res) => {
   res.sendStatus(200);

--- a/src/app.js
+++ b/src/app.js
@@ -11,9 +11,9 @@ if (process.env.NODE_ENV !== 'test') {
 }
 app.use(bodyParser.json());
 
-streamClient.on('member-registered', store.createMember);
-streamClient.on('member-removed', store.deleteMember);
-streamClient.on('member-edited', store.updateMember);
+streamClient.on('member-registered', store.registerMember);
+streamClient.on('member-removed', store.removeMember);
+streamClient.on('member-edited', store.editMember);
 
 app.post('/events', streamClient.listen());
 app.post('/mail', sendGroupMail);

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,13 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const morgan = require('morgan');
 const streamClient = require('./streamClient');
 const store = require('./store');
 
 const app = express();
+if (process.env.NODE_ENV !== 'test') {
+  app.use(morgan('dev'));
+}
 app.use(bodyParser.json());
 
 streamClient.on('member-registered', store.createMember);

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  stream: {
+    streamName: process.env.STREAM_NAME || 'rabblerouser_stream',
+    listenerAuthToken: process.env.LISTENER_AUTH_TOKEN || 'secret',
+    archiveBucket: process.env.ARCHIVE_BUCKET || 'rr-event-archive',
+  },
+
+  emailBucket: process.env.S3_EMAIL_BUCKET || 'email-bucket',
+
+  aws: {
+    region: process.env.AWS_REGION || 'ap-southeast-2',
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'FAKE',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'ALSO FAKE',
+    kinesisEndpoint: process.env.KINESIS_ENDPOINT,
+    s3Endpoint: process.env.S3_ENDPOINT,
+  },
+};

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ module.exports = {
     archiveBucket: process.env.ARCHIVE_BUCKET || 'rr-event-archive',
   },
 
-  emailBucket: process.env.S3_EMAIL_BUCKET || 'email-bucket',
+  emailBucket: process.env.S3_EMAILS_BUCKET || 'email-bucket',
   domain: process.env.DOMAIN || 'example.com',
 
   aws: {

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@ module.exports = {
   },
 
   emailBucket: process.env.S3_EMAIL_BUCKET || 'email-bucket',
+  domain: process.env.DOMAIN || 'example.com',
 
   aws: {
     region: process.env.AWS_REGION || 'ap-southeast-2',

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,6 @@
+const winston = require('winston');
+
+const level = process.env.NODE_ENV === 'test' ? -1 : 'debug';
+const transports = [new (winston.transports.Console)()];
+
+module.exports = new winston.Logger({ level, transports });

--- a/src/reducers/__tests__/adminsTest.js
+++ b/src/reducers/__tests__/adminsTest.js
@@ -1,0 +1,49 @@
+const { reducer: admins, getEmails } = require('../admins');
+
+describe('admins reducer', () => {
+  it('has no admins by default', () => {
+    expect(admins(undefined, {})).to.eql([]);
+  });
+
+  it('preserves existing state for uninteresting actions', () => {
+    expect(admins([{ id: 'blah' }], { type: 'NOT_INTERESTING' })).to.eql([{ id: 'blah' }]);
+  });
+
+  it('creates an admin', () => {
+    const state = [{ id: 'existing-admin', email: 'existing@example.com' }];
+    const action = { type: 'CREATE_ADMIN', admin: { id: 'new-admin', email: 'new@example.com', name: 'Me' } };
+    expect(admins(state, action)).to.eql([
+      { id: 'existing-admin', email: 'existing@example.com' },
+      { id: 'new-admin', email: 'new@example.com' },
+    ]);
+  });
+
+  it('deletes an admin', () => {
+    const event = { type: 'REMOVE_ADMIN', admin: { id: 'delete-me' } };
+    const state = [{ id: 'delete-me', email: 'delete@example.com' }, { id: 'keep-me', email: 'keep@example.com' }];
+    expect(admins(state, event)).to.eql([{ id: 'keep-me', email: 'keep@example.com' }]);
+  });
+
+  it('edits an admin', () => {
+    const event = {
+      type: 'EDIT_ADMIN',
+      admin: { id: 'updated-admin', email: 'updated@example.com', name: 'Updated Member' },
+    };
+    const state = [
+      { id: 'updated-admin', email: 'old@example.com' },
+      { id: 'unchanged-admin', email: 'unchanged@example.com' },
+    ];
+    expect(admins(state, event)).to.eql([
+      { id: 'updated-admin', email: 'updated@example.com' },
+      { id: 'unchanged-admin', email: 'unchanged@example.com' },
+    ]);
+  });
+});
+
+describe('getEmails', () => {
+  it('extracts emails from the admin data', () => {
+    const adminData = [{ id: 'first', email: 'first@example.com' }, { id: 'second', email: 'second@example.com' }];
+
+    expect(getEmails(adminData)).to.eql(['first@example.com', 'second@example.com']);
+  });
+});

--- a/src/reducers/__tests__/membersTest.js
+++ b/src/reducers/__tests__/membersTest.js
@@ -1,4 +1,4 @@
-const members = require('../members');
+const { reducer: members, getEmails } = require('../members');
 
 describe('members reducer', () => {
   it('has no members by default', () => {
@@ -10,31 +10,40 @@ describe('members reducer', () => {
   });
 
   it('creates a member', () => {
-    const state = [{ id: 'existing-member' }];
-    expect(members(state, { type: 'CREATE_MEMBER', member: { id: 'blah' } })).to.eql([
-      { id: 'existing-member' },
-      { id: 'blah' },
+    const state = [{ id: 'existing-member', email: 'existing@example.com' }];
+    const action = { type: 'CREATE_MEMBER', member: { id: 'new-member', email: 'new@example.com', name: 'Me' } };
+    expect(members(state, action)).to.eql([
+      { id: 'existing-member', email: 'existing@example.com' },
+      { id: 'new-member', email: 'new@example.com' },
     ]);
   });
 
   it('deletes a member', () => {
-    const event = { type: 'DELETE_MEMBER', member: { id: 'existing-member' } };
-    const state = [{ id: 'existing-member' }, { id: 'preserved-member' }];
-    expect(members(state, event)).to.eql([{ id: 'preserved-member' }]);
+    const event = { type: 'DELETE_MEMBER', member: { id: 'delete-me' } };
+    const state = [{ id: 'delete-me', email: 'delete@example.com' }, { id: 'keep-me', email: 'keep@example.com' }];
+    expect(members(state, event)).to.eql([{ id: 'keep-me', email: 'keep@example.com' }]);
   });
 
   it('edits a member', () => {
     const event = {
       type: 'UPDATE_MEMBER',
-      member: { id: 'existing-member', email: 'new@email.com' },
+      member: { id: 'updated-member', email: 'updated@example.com', name: 'Updated Member' },
     };
     const state = [
-      { id: 'existing-member', email: 'old@email.com', name: 'Person McPersonface' },
-      { id: 'preserved-member' },
+      { id: 'updated-member', email: 'old@example.com' },
+      { id: 'unchanged-member', email: 'unchanged@example.com' },
     ];
     expect(members(state, event)).to.eql([
-      { id: 'existing-member', email: 'new@email.com', name: 'Person McPersonface' },
-      { id: 'preserved-member' },
+      { id: 'updated-member', email: 'updated@example.com' },
+      { id: 'unchanged-member', email: 'unchanged@example.com' },
     ]);
+  });
+});
+
+describe('getEmails', () => {
+  it('extracts emails from the member data', () => {
+    const memberData = [{ id: 'first', email: 'first@example.com' }, { id: 'second', email: 'second@example.com' }];
+
+    expect(getEmails(memberData)).to.eql(['first@example.com', 'second@example.com']);
   });
 });

--- a/src/reducers/__tests__/membersTest.js
+++ b/src/reducers/__tests__/membersTest.js
@@ -11,7 +11,7 @@ describe('members reducer', () => {
 
   it('creates a member', () => {
     const state = [{ id: 'existing-member', email: 'existing@example.com' }];
-    const action = { type: 'CREATE_MEMBER', member: { id: 'new-member', email: 'new@example.com', name: 'Me' } };
+    const action = { type: 'REGISTER_MEMBER', member: { id: 'new-member', email: 'new@example.com', name: 'Me' } };
     expect(members(state, action)).to.eql([
       { id: 'existing-member', email: 'existing@example.com' },
       { id: 'new-member', email: 'new@example.com' },
@@ -19,14 +19,14 @@ describe('members reducer', () => {
   });
 
   it('deletes a member', () => {
-    const event = { type: 'DELETE_MEMBER', member: { id: 'delete-me' } };
+    const event = { type: 'REMOVE_MEMBER', member: { id: 'delete-me' } };
     const state = [{ id: 'delete-me', email: 'delete@example.com' }, { id: 'keep-me', email: 'keep@example.com' }];
     expect(members(state, event)).to.eql([{ id: 'keep-me', email: 'keep@example.com' }]);
   });
 
   it('edits a member', () => {
     const event = {
-      type: 'UPDATE_MEMBER',
+      type: 'EDIT_MEMBER',
       member: { id: 'updated-member', email: 'updated@example.com', name: 'Updated Member' },
     };
     const state = [

--- a/src/reducers/admins.js
+++ b/src/reducers/admins.js
@@ -1,0 +1,25 @@
+const defaultState = [];
+
+const reducer = (state = defaultState, action) => {
+  switch (action.type) {
+    case 'CREATE_ADMIN':
+      return state.concat({ id: action.admin.id, email: action.admin.email });
+    case 'REMOVE_ADMIN':
+      return state.filter(admin => admin.id !== action.admin.id);
+    case 'EDIT_ADMIN':
+      return state.map(admin => (
+        admin.id === action.admin.id ?
+          { id: action.admin.id, email: action.admin.email } :
+          admin
+      ));
+    default:
+      return state;
+  }
+};
+
+const getEmails = admins => admins.map(admin => admin.email);
+
+module.exports = {
+  reducer,
+  getEmails,
+};

--- a/src/reducers/members.js
+++ b/src/reducers/members.js
@@ -1,18 +1,25 @@
 const defaultState = [];
 
-const members = (state = defaultState, action) => {
+const reducer = (state = defaultState, action) => {
   switch (action.type) {
     case 'CREATE_MEMBER':
-      return state.concat(action.member);
+      return state.concat({ id: action.member.id, email: action.member.email });
     case 'DELETE_MEMBER':
       return state.filter(member => member.id !== action.member.id);
     case 'UPDATE_MEMBER':
       return state.map(member => (
-        member.id === action.member.id ? Object.assign({}, member, action.member) : member
+        member.id === action.member.id ?
+          { id: action.member.id, email: action.member.email } :
+          member
       ));
     default:
       return state;
   }
 };
 
-module.exports = members;
+const getEmails = members => members.map(member => member.email);
+
+module.exports = {
+  reducer,
+  getEmails,
+};

--- a/src/reducers/members.js
+++ b/src/reducers/members.js
@@ -2,11 +2,11 @@ const defaultState = [];
 
 const reducer = (state = defaultState, action) => {
   switch (action.type) {
-    case 'CREATE_MEMBER':
+    case 'REGISTER_MEMBER':
       return state.concat({ id: action.member.id, email: action.member.email });
-    case 'DELETE_MEMBER':
+    case 'REMOVE_MEMBER':
       return state.filter(member => member.id !== action.member.id);
-    case 'UPDATE_MEMBER':
+    case 'EDIT_MEMBER':
       return state.map(member => (
         member.id === action.member.id ?
           { id: action.member.id, email: action.member.email } :

--- a/src/sendGroupMail.js
+++ b/src/sendGroupMail.js
@@ -24,7 +24,7 @@ const publishEmailEvent = (bodyLocation, email) => {
     to: store.getMemberEmails(),
     subject: email.subject,
     bodyLocation: {
-      bodyLocation
+      bodyLocation,
     },
   })
     .catch(() => Promise.reject({ status: 500, message: 'Could not publish event to stream' }));

--- a/src/sendGroupMail.js
+++ b/src/sendGroupMail.js
@@ -1,7 +1,38 @@
-const sendGroupMail = (req, res) => {
-  console.log(req.body);
+const AWS = require('aws-sdk');
+const uuid = require('uuid');
+const store = require('./store');
+const streamClient = require('./streamClient');
+const config = require('./config');
+const logger = require('./logger');
 
-  res.send(202);
+const { region, accessKeyId, secretAccessKey, s3Endpoint: endpoint } = config.aws;
+const emailBucket = config.emailBucket;
+
+const handleError = (res, status, error) => () => {
+  logger.error(error);
+  res.status(status).send({ error });
+};
+
+const sendGroupMail = (req, res) => {
+  const s3 = new AWS.S3({ region, accessKeyId, secretAccessKey, endpoint });
+  const emailObjectKey = req.body.emailRecords[0].key;
+
+  return s3.getObject({ Bucket: emailBucket, Key: emailObjectKey }).promise()
+    .then((object) => {
+      logger.info(`Retrieved email data from S3 object: ${object.Body}`);
+
+      const memberEmails = store.getMembers().map(member => member.email);
+
+      return streamClient.publish('send-email', {
+        id: uuid.v4(),
+        to: memberEmails,
+        bodyLocation: emailObjectKey,
+      });
+    }, handleError(res, 400, 'Could not download S3 object'))
+    .then(() => {
+      res.status(202).send();
+    })
+    .catch(handleError(res, 500, 'Could not publish event to stream'));
 };
 
 module.exports = sendGroupMail;

--- a/src/sendGroupMail.js
+++ b/src/sendGroupMail.js
@@ -1,0 +1,7 @@
+const sendGroupMail = (req, res) => {
+  console.log(req.body);
+
+  res.send(202);
+};
+
+module.exports = sendGroupMail;

--- a/src/sendGroupMail.js
+++ b/src/sendGroupMail.js
@@ -14,11 +14,10 @@ const publishEmailEvent = bodyLocation => (email) => {
     return Promise.reject({ status: 400, message: 'Not a valid email recipient' });
   }
 
-  const memberEmails = store.getMembers().map(member => member.email);
   return streamClient.publish('send-email', {
     id: uuid.v4(),
     from: email.from.value[0].address,
-    to: memberEmails,
+    to: store.getMemberEmails(),
     subject: email.subject,
     bodyLocation,
   })

--- a/src/sendGroupMail.js
+++ b/src/sendGroupMail.js
@@ -23,7 +23,9 @@ const publishEmailEvent = (bodyLocation, email) => {
     from,
     to: store.getMemberEmails(),
     subject: email.subject,
-    bodyLocation,
+    bodyLocation: {
+      bodyLocation
+    },
   })
     .catch(() => Promise.reject({ status: 500, message: 'Could not publish event to stream' }));
 };

--- a/src/sendGroupMail.js
+++ b/src/sendGroupMail.js
@@ -10,13 +10,17 @@ const { region, accessKeyId, secretAccessKey, s3Endpoint: endpoint } = config.aw
 const emailBucket = config.emailBucket;
 
 const publishEmailEvent = bodyLocation => (email) => {
+  const from = email.from.value[0].address;
+  if (!store.getAuthorisedSenders().includes(from)) {
+    return Promise.reject({ status: 401, message: 'Not an authorised email sender' });
+  }
   if (email.to.value[0].address !== `everyone@${config.domain}`) {
     return Promise.reject({ status: 400, message: 'Not a valid email recipient' });
   }
 
   return streamClient.publish('send-email', {
     id: uuid.v4(),
-    from: email.from.value[0].address,
+    from,
     to: store.getMemberEmails(),
     subject: email.subject,
     bodyLocation,

--- a/src/sendGroupMail.js
+++ b/src/sendGroupMail.js
@@ -34,6 +34,7 @@ const getEmailObjectAndPublishEvent = s3 => async (emailRecord) => {
     const email = await mailParser.simpleParser(s3Object.Body);
     return publishEmailEvent(emailRecord.key, email);
   } catch (e) {
+    logger.error(`Could not download S3 object: ${emailBucket}/${emailRecord.key} : ${e}`);
     return Promise.reject({ status: 400, message: 'Could not download S3 object' });
   }
 };

--- a/src/store.js
+++ b/src/store.js
@@ -18,7 +18,7 @@ const dispatch = (action) => {
 module.exports = {
   getMemberEmails: () => members.getEmails(store.getState().members),
 
-  createMember: member => dispatch({ type: 'CREATE_MEMBER', member }),
-  deleteMember: member => dispatch({ type: 'DELETE_MEMBER', member }),
-  updateMember: member => dispatch({ type: 'UPDATE_MEMBER', member }),
+  registerMember: member => dispatch({ type: 'REGISTER_MEMBER', member }),
+  removeMember: member => dispatch({ type: 'REMOVE_MEMBER', member }),
+  editMember: member => dispatch({ type: 'EDIT_MEMBER', member }),
 };

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,11 @@
 const redux = require('redux');
 const members = require('./reducers/members');
+const admins = require('./reducers/admins');
 
-const rootReducer = redux.combineReducers({ members: members.reducer });
+const rootReducer = redux.combineReducers({
+  members: members.reducer,
+  admins: admins.reducer,
+});
 
 const store = redux.createStore(rootReducer);
 
@@ -21,4 +25,10 @@ module.exports = {
   registerMember: member => dispatch({ type: 'REGISTER_MEMBER', member }),
   removeMember: member => dispatch({ type: 'REMOVE_MEMBER', member }),
   editMember: member => dispatch({ type: 'EDIT_MEMBER', member }),
+
+  getAuthorisedSenders: () => admins.getEmails(store.getState().admins),
+
+  createAdmin: admin => dispatch({ type: 'CREATE_ADMIN', admin }),
+  removeAdmin: admin => dispatch({ type: 'REMOVE_ADMIN', admin }),
+  editAdmin: admin => dispatch({ type: 'EDIT_ADMIN', admin }),
 };

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,7 @@
 const redux = require('redux');
 const members = require('./reducers/members');
 
-const rootReducer = redux.combineReducers({ members });
+const rootReducer = redux.combineReducers({ members: members.reducer });
 
 const store = redux.createStore(rootReducer);
 
@@ -16,7 +16,8 @@ const dispatch = (action) => {
 };
 
 module.exports = {
-  getMembers: () => store.getState().members,
+  getMemberEmails: () => members.getEmails(store.getState().members),
+
   createMember: member => dispatch({ type: 'CREATE_MEMBER', member }),
   deleteMember: member => dispatch({ type: 'DELETE_MEMBER', member }),
   updateMember: member => dispatch({ type: 'UPDATE_MEMBER', member }),

--- a/src/streamClient.js
+++ b/src/streamClient.js
@@ -1,16 +1,17 @@
 const createClient = require('@rabblerouser/stream-client');
+const config = require('./config');
 
 const streamClientSettings = {
-  publishToStream: process.env.STREAM_NAME || 'rabblerouser_stream',
-  listenWithAuthToken: process.env.LISTENER_AUTH_TOKEN || 'secret',
-  readArchiveFromBucket: process.env.ARCHIVE_BUCKET || 'rr-event-archive',
+  publishToStream: config.stream.streamName,
+  listenWithAuthToken: config.stream.listenerAuthToken,
+  readArchiveFromBucket: config.stream.archiveBucket,
 
-  region: process.env.AWS_REGION || 'ap-southeast-2',
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'FAKE',
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'ALSO FAKE',
+  region: config.aws.region,
+  accessKeyId: config.aws.accessKeyId,
+  secretAccessKey: config.aws.secretAccessKey,
 
-  kinesisEndpoint: process.env.KINESIS_ENDPOINT,
-  s3Endpoint: process.env.S3_ENDPOINT,
+  kinesisEndpoint: config.aws.kinesisEndpoint,
+  s3Endpoint: config.aws.s3Endpoint,
 };
 
 module.exports = createClient(streamClientSettings);


### PR DESCRIPTION
This should be everything the group-mailer needs for our first release. Resolves rabblerouser/core#141.

 - Add a `POST /mail` endpoint
 - Fetch specified S3 object and parse its email contents
 - Validate that the sender is an admin (subscribes to admin events to determine this)
 - Validate that the recipient is `everyone@domain`
 - Resolve 'everyone' the actual list of members (subscribes to member events to determine this)
 - Publish the event with all relevant info
 - Add logging
 - Also adds a couple of @rdoh's suggestions, like a separate config file, and unifying some of the domain terminology around events and actions
 - Also a couple of little tooling changes like linting, docker, etc

<!---
@huboard:{"order":3.9999500049995,"milestone_order":7,"custom_state":""}
-->
